### PR TITLE
protect for null value

### DIFF
--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -49,7 +49,7 @@ export default Ember.Component.extend({
         suggestion = selection.filter((option) => {
           return option.__isSuggestion__;
         })[0];
-      } else if (selection.__isSuggestion__) {
+      } else if (selection && selection.__isSuggestion__) {
         suggestion = selection;
       }
 


### PR DESCRIPTION
when using `allowClear` selection might become `null`, which breaks with current code and should be guarded for