### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "ember server",
     "test": "ember try:testall"
   },
-  "repository": "",
+  "repository": "https://github.com/cibernox/ember-power-select-with-create",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
This lets npmjs.org (and other NPM mirrors) pick up the repo URL.