### PR TITLE
Do not create duplicates

### DIFF
--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -26,6 +26,7 @@ export default Ember.Component.extend({
   actions: {
     searchAndSuggest(term) {
       let newOptions = this.get('optionsArray');
+      let match = false;
 
       if (term.length === 0) {
         return newOptions;
@@ -33,8 +34,18 @@ export default Ember.Component.extend({
 
       if (this.get('search')) {
         return Ember.RSVP.resolve(this.get('search')(term)).then((results) =>  {
-          results.unshift(this.buildSuggestionForTerm(term));
-          return results;
+          results.forEach((result) => {
+            if (term.toLowerCase() === result.get(this.get('searchField')).toLowerCase()) {
+              return match = true;
+            }
+          });
+
+          if (match) {
+            return results;
+          } else {
+            results.unshift(this.buildSuggestionForTerm(term));
+            return results;
+          }
         });
       }
 

--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -26,7 +26,7 @@ export default Ember.Component.extend({
   actions: {
     searchAndSuggest(term) {
       let newOptions = this.get('optionsArray');
-      let match = false;
+      let lowerCaseTerm = term.toLowerCase();
 
       if (term.length === 0) {
         return newOptions;
@@ -34,11 +34,7 @@ export default Ember.Component.extend({
 
       if (this.get('search')) {
         return Ember.RSVP.resolve(this.get('search')(term)).then((results) =>  {
-          results.forEach((result) => {
-            if (term.toLowerCase() === result.get(this.get('searchField')).toLowerCase()) {
-              return match = true;
-            }
-          });
+          let match = results.some(result => result.get(this.get('searchField')).toLowerCase() === lowerCaseTerm);
 
           if (match) {
             return results;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-power-select-with-create",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",
@@ -47,7 +47,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-power-select": "^0.8.0-beta.12"
+    "ember-power-select": "^0.8.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This is to prevent the user creating duplicate items by removing the suggestion to create an item once a match has been found in the options array.