### PR TITLE
Update passed values

### DIFF
--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -25,6 +25,10 @@ export default Ember.Component.extend({
     }
   }),
 
+  powerSelectComponentName: computed('multiple', function() {
+    return this.get('multiple') ? 'power-select-multiple' : 'power-select';
+  }),
+
   // Actions
   actions: {
     searchAndSuggest(term) {

--- a/addon/templates/components/power-select-with-create.hbs
+++ b/addon/templates/components/power-select-with-create.hbs
@@ -1,5 +1,4 @@
-{{#if multiple}}
-  {{#power-select-multiple
+{{#component powerSelectComponentName
     options=optionsArray
     selected=selected
     search=(action "searchAndSuggest")
@@ -33,53 +32,11 @@
     triggerClass=triggerClass
     dropdownClass=dropdownClass
     extra=extra
-    as |option term|}}
-    {{#if option.__isSuggestion__}}
-      {{option.text}}
-    {{else}}
-      {{yield option term}}
-    {{/if}}
-  {{/power-select-multiple}}
-{{else}}
-  {{#power-select
-    options=optionsArray
-    selected=selected
-    search=(action "searchAndSuggest")
-    onchange=(action "selectOrCreate")
-    onkeydown=onkeydown
-    onfocus=onfocus
-    onopen=onopen
-    onclose=onclose
-    disabled=disabled
-    placeholder=placeholder
-    searchEnabled=searchEnabled
-    searchPlaceholder=searchPlaceholder
-    loadingMessage=loadingMessage
-    noMatchesMessage=noMatchesMessage
-    searchMessage=searchMessage
-    triggerComponent=triggerComponent
-    selectedItemComponent=selectedItemComponent
-    beforeOptionsComponent=beforeOptionsComponent
-    optionsComponent=optionsComponent
-    afterOptionsComponent=afterOptionsComponent
-    matcher=matcher
-    searchField=searchField
-    renderInPlace=renderInPlace
-    allowClear=allowClear
-    verticalPosition=verticalPosition
-    closeOnSelect=closeOnSelect
-    opened=opened
-    tabindex=tabindex
-    dir=dir
-    class=class
-    triggerClass=triggerClass
-    dropdownClass=dropdownClass
-    extra=extra
-    as |option term|}}
-    {{#if option.__isSuggestion__}}
-      {{option.text}}
-    {{else}}
-      {{yield option term}}
-    {{/if}}
-  {{/power-select}}
-{{/if}}
+    as |option term|
+}}
+  {{#if option.__isSuggestion__}}
+    {{option.text}}
+  {{else}}
+    {{yield option term}}
+  {{/if}}
+{{/component}}

--- a/addon/templates/components/power-select-with-create.hbs
+++ b/addon/templates/components/power-select-with-create.hbs
@@ -22,16 +22,13 @@
     searchMessage=searchMessage
     triggerComponent=triggerComponent
     selectedItemComponent=selectedItemComponent
+    afterOptionsComponent=afterOptionsComponent
     beforeOptionsComponent=beforeOptionsComponent
     optionsComponent=optionsComponent
-    afterOptionsComponent=afterOptionsComponent
     renderInPlace=renderInPlace
+    closeOnSelect=closeOnSelect
     allowClear=allowClear
     verticalPosition=verticalPosition
-    closeOnSelect=closeOnSelect
-    opened=opened
-    tabindex=tabindex
-    dir=dir
     horizontalPosition=horizontalPosition
     class=class
     triggerClass=triggerClass
@@ -40,6 +37,8 @@
     initiallyOpened=initiallyOpened
     matchTriggerWidth=matchTriggerWidth
     destination=destination
+    tabindex=tabindex
+    dir=dir
     as |option term|
 }}
   {{#if option.__isSuggestion__}}

--- a/addon/templates/components/power-select-with-create.hbs
+++ b/addon/templates/components/power-select-with-create.hbs
@@ -1,16 +1,22 @@
 {{#component powerSelectComponentName
+    ariaDescribedBy=ariaDescribedBy
+    ariaInvalid=ariaInvalid
+    ariaLabel=ariaLabel
+    ariaLabelledBy=ariaLabelledBy
     options=optionsArray
     selected=selected
-    search=(action "searchAndSuggest")
     onchange=(action "selectOrCreate")
     onkeydown=onkeydown
     onfocus=onfocus
     onopen=onopen
     onclose=onclose
+    search=(action "searchAndSuggest")
     disabled=disabled
     placeholder=placeholder
     searchEnabled=searchEnabled
     searchPlaceholder=searchPlaceholder
+    searchField=searchField
+    matcher=matcher
     loadingMessage=loadingMessage
     noMatchesMessage=noMatchesMessage
     searchMessage=searchMessage
@@ -19,8 +25,6 @@
     beforeOptionsComponent=beforeOptionsComponent
     optionsComponent=optionsComponent
     afterOptionsComponent=afterOptionsComponent
-    matcher=matcher
-    searchField=searchField
     renderInPlace=renderInPlace
     allowClear=allowClear
     verticalPosition=verticalPosition
@@ -28,10 +32,14 @@
     opened=opened
     tabindex=tabindex
     dir=dir
+    horizontalPosition=horizontalPosition
     class=class
     triggerClass=triggerClass
     dropdownClass=dropdownClass
     extra=extra
+    initiallyOpened=initiallyOpened
+    matchTriggerWidth=matchTriggerWidth
+    destination=destination
     as |option term|
 }}
   {{#if option.__isSuggestion__}}


### PR DESCRIPTION
Closes #16 

@cibernox 

Currently, there are options that are not part of the [EPS API reference](http://www.ember-power-select.com/docs/api-reference). 

Should I remove any of the following options? (maybe some are no longer supported?)

- `searchMessage`
- `beforeOptionsComponent`
- `afterOptionsComponent`
- `closeOnSelect`
- `opened`
- `tabindex`
- `dir`