### PR TITLE
Add support for the showCreateWhen in combination with async search

### DIFF
--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -29,6 +29,10 @@ export default Ember.Component.extend({
     return this.get('multiple') ? 'power-select-multiple' : 'power-select';
   }),
 
+  shouldShowCreateOption(term) {
+    return this.get('showCreateWhen') ? this.get('showCreateWhen')(term) : true;
+  },
+
   // Actions
   actions: {
     searchAndSuggest(term) {
@@ -40,15 +44,15 @@ export default Ember.Component.extend({
 
       if (this.get('search')) {
         return Ember.RSVP.resolve(this.get('search')(term)).then((results) =>  {
-          results.unshift(this.buildSuggestionForTerm(term));
+          if (this.shouldShowCreateOption(term)) {
+            results.unshift(this.buildSuggestionForTerm(term));
+          }
           return results;
         });
       }
 
       newOptions = this.filter(Ember.A(newOptions), term);
-
-      let shouldShowCreateOption = this.get('showCreateWhen') ? this.get('showCreateWhen')(term) : true;
-      if (shouldShowCreateOption) {
+      if (this.shouldShowCreateOption(term)) {
         newOptions.unshift(this.buildSuggestionForTerm(term));
       }
 


### PR DESCRIPTION
I was trying to use this addon with an async search + showCreateWhen to only display the "Add a new" option when that wasn't present in the search results. It didn't work so I dug through the code and found that "showCreateWhen" is only used when the array options are passed. 

This PR makes the property also work on the async search. Feel free to make suggestions and improvements, this worked for me. Thanks for addon by the way.