### PR TITLE
Provide the shouldShowCreate action with the options found

### DIFF
--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -29,8 +29,8 @@ export default Ember.Component.extend({
     return this.get('multiple') ? 'power-select-multiple' : 'power-select';
   }),
 
-  shouldShowCreateOption(term) {
-    return this.get('showCreateWhen') ? this.get('showCreateWhen')(term) : true;
+  shouldShowCreateOption(term, options) {
+    return this.get('showCreateWhen') ? this.get('showCreateWhen')(term, options) : true;
   },
 
   // Actions
@@ -48,7 +48,7 @@ export default Ember.Component.extend({
             results = results.toArray();
           }
 
-          if (this.shouldShowCreateOption(term)) {
+          if (this.shouldShowCreateOption(term, results)) {
             results.unshift(this.buildSuggestionForTerm(term));
           }
 
@@ -57,7 +57,7 @@ export default Ember.Component.extend({
       }
 
       newOptions = this.filter(Ember.A(newOptions), term);
-      if (this.shouldShowCreateOption(term)) {
+      if (this.shouldShowCreateOption(term, newOptions)) {
         newOptions.unshift(this.buildSuggestionForTerm(term));
       }
 

--- a/tests/integration/components/power-select-with-create-test.js
+++ b/tests/integration/components/power-select-with-create-test.js
@@ -302,6 +302,64 @@ test('it lets the user decide if the create option should be shown', function(as
   assert.equal(this.$('.ember-power-select-option').length, 2);
 });
 
+test('shouldShowCreate called with options when backed by static array', function(assert) {
+  assert.expect(1);
+
+  const countries = [{name: 'Canada'}];
+  this.set('countries', countries);
+  this.on('shouldShowCreate', (term, options) => {
+    assert.deepEqual(options, countries);
+    return true;
+  });
+
+  this.render(hbs`
+    {{#power-select-with-create
+        options=countries
+        searchField="name"
+        oncreate=(action "createCountry")
+        showCreateWhen=(action "shouldShowCreate")
+        renderInPlace=true as |country|
+    }}
+      {{country.name}}
+    {{/power-select-with-create}}
+  `);
+
+  clickTrigger();
+  typeInSearch('can');
+});
+
+test('shouldShowCreate called with options when backed by async search', function(assert) {
+  assert.expect(1);
+
+  const countries = [{name: 'Canada'}];
+  this.on('searchCountries', () => {
+    return new Ember.RSVP.Promise((resolve) => {
+      resolve(countries);
+    });
+  });
+
+  this.on('shouldShowCreate', (term, options) => {
+    assert.deepEqual(options, countries);
+    return true;
+  });
+
+  this.render(hbs`
+    {{#power-select-with-create
+        search=(action "searchCountries")
+        onchange=(action (mut selectedCountries))
+        oncreate=(action "createCountry")
+        showCreateWhen=(action "shouldShowCreate")
+        renderInPlace=true
+         as |country|
+    }}
+      {{country.name}}
+    {{/power-select-with-create}}
+  `);
+
+  clickTrigger();
+  typeInSearch('can');
+});
+
 test('shouldShowCreate works with async search', function(assert) {
   assert.expect(5);
 


### PR DESCRIPTION
* This helps for asynchronous searching as the user doesn't have to 
  ensure the options isn't a promise when accessing them to determine
  if we should show the create option.