### PR TITLE
Fix for #44, yielding create option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ You can provide `showCreatePosition` property to control the position(bottom|top
   {{country.name}}
 {{/power-select-with-create}}
 ```
+
+#### Yield create option
+
+You can provide `yieldCreateOption` property to control whether or not the create option will be yielded like any other option. Default - `false`.
+
+```hbs
+{{#power-select-with-create
+    options=tags
+    searchField="name"
+    selected=selectedTag
+    selected=selectedCountry
+    oncreate=(action "createTag")
+    yieldCreateOption=true as |tag|
+}}
+  {{#if tag.isSuggestion}}
+    <span class="suggested-tag">{{tag.text}}</span>
+  {{else}}
+    <span class="tag">{{tag.name}}</span>
+  {{/if}}
+{{/power-select-with-create}}
+```
+
+*note, the `text` property on the create option is the result of the `buildSuggestionLabel` action. Default: `Add "${term}"...`.
+
 ### Demo
 
 [https://ember-power-select-with-create.pagefrontapp.com/](https://ember-power-select-with-create.pagefrontapp.com/)

--- a/README.md
+++ b/README.md
@@ -76,17 +76,16 @@ You can provide `yieldCreateOption` property to control whether or not the creat
 
 ```hbs
 {{#power-select-with-create
-    options=tags
+    options=countries
     searchField="name"
-    selected=selectedTag
     selected=selectedCountry
-    oncreate=(action "createTag")
-    yieldCreateOption=true as |tag|
+    oncreate=(action "createCountry")
+    yieldCreateOption=true as |country|
 }}
-  {{#if tag.isSuggestion}}
-    <span class="suggested-tag">{{tag.text}}</span>
+  {{#if country.isSuggestion}}
+    <span class="suggested-country">{{country.text}}</span>
   {{else}}
-    <span class="tag">{{tag.name}}</span>
+    <span class="country">{{country.name}}</span>
   {{/if}}
 {{/power-select-with-create}}
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can provide `yieldCreateOption` property to control whether or not the creat
 {{/power-select-with-create}}
 ```
 
-*note, the `text` property on the create option is the result of the `buildSuggestionLabel` action. Default: `Add "${term}"...`.
+*note, the `text` property on the create option is the result of the `buildSuggestion` action. Default: `Add "${term}"...`.*
 
 ### Demo
 

--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -8,6 +8,7 @@ export default Ember.Component.extend({
   layout: layout,
   matcher: defaultMatcher,
   yieldCreateOption: false,
+  isSuggestionField: '__isSuggestion__',
 
   // Lifecycle hooks
   init() {
@@ -72,11 +73,13 @@ export default Ember.Component.extend({
 
     selectOrCreate(selection, select) {
       let suggestion;
+      let isSuggestionField = this.get('isSuggestionField');
+
       if (this.get('multiple')) {
         suggestion = selection.filter((option) => {
-          return option.isSuggestion;
+          return option[isSuggestionField];
         })[0];
-      } else if (selection && selection.isSuggestion) {
+      } else if (selection && selection[isSuggestionField]) {
         suggestion = selection;
       }
 
@@ -100,11 +103,14 @@ export default Ember.Component.extend({
   },
 
   buildSuggestionForTerm(term) {
-    return {
-      isSuggestion: true,
+    let suggestion = {
       __value__: term,
       text: this.buildSuggestionLabel(term),
     };
+
+    suggestion[this.get('isSuggestionField')] = true;
+
+    return suggestion;
   },
 
   buildSuggestionLabel(term) {

--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -7,6 +7,7 @@ export default Ember.Component.extend({
   tagName: '',
   layout: layout,
   matcher: defaultMatcher,
+  yieldCreateOption: false,
 
   // Lifecycle hooks
   init() {
@@ -73,9 +74,9 @@ export default Ember.Component.extend({
       let suggestion;
       if (this.get('multiple')) {
         suggestion = selection.filter((option) => {
-          return option.__isSuggestion__;
+          return option.isSuggestion;
         })[0];
-      } else if (selection && selection.__isSuggestion__) {
+      } else if (selection && selection.isSuggestion) {
         suggestion = selection;
       }
 
@@ -100,7 +101,7 @@ export default Ember.Component.extend({
 
   buildSuggestionForTerm(term) {
     return {
-      __isSuggestion__: true,
+      isSuggestion: true,
       __value__: term,
       text: this.buildSuggestionLabel(term),
     };

--- a/addon/templates/components/power-select-with-create.hbs
+++ b/addon/templates/components/power-select-with-create.hbs
@@ -41,8 +41,12 @@
     tabindex=tabindex
     dir=dir
     as |option term|}}
-    {{#if option.__isSuggestion__}}
-      {{option.text}}
+    {{#if option.isSuggestion}}
+      {{#if yieldCreateOption}}
+        {{yield option}}
+      {{else}}
+        {{option.text}}
+      {{/if}}
     {{else}}
       {{yield option term}}
     {{/if}}
@@ -90,8 +94,12 @@
     tabindex=tabindex
     dir=dir
     as |option term|}}
-    {{#if option.__isSuggestion__}}
-      {{option.text}}
+    {{#if option.isSuggestion}}
+      {{#if yieldCreateOption}}
+        {{yield option}}
+      {{else}}
+        {{option.text}}
+      {{/if}}
     {{else}}
       {{yield option term}}
     {{/if}}

--- a/addon/templates/components/power-select-with-create.hbs
+++ b/addon/templates/components/power-select-with-create.hbs
@@ -41,7 +41,7 @@
     tabindex=tabindex
     dir=dir
     as |option term|}}
-    {{#if option.isSuggestion}}
+    {{#if get option isSuggestionField}}
       {{#if yieldCreateOption}}
         {{yield option}}
       {{else}}
@@ -94,7 +94,7 @@
     tabindex=tabindex
     dir=dir
     as |option term|}}
-    {{#if option.isSuggestion}}
+    {{#if get option isSuggestionField}}
       {{#if yieldCreateOption}}
         {{yield option}}
       {{else}}

--- a/tests/integration/components/power-select-with-create-test.js
+++ b/tests/integration/components/power-select-with-create-test.js
@@ -126,6 +126,63 @@ test('it displays option to add item with custom text at bottom', function(asser
   );
 });
 
+test('it does not yield the create option by default', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`
+    {{#power-select-with-create
+        options=countries
+        oncreate=(action "createCountry")
+        searchField='name'
+        showCreatePosition="bottom"
+        renderInPlace=true as |country|
+    }}
+      {{#if country.isSuggestion}}
+        <span class="is-suggested">{{country.text}}</span>
+      {{else}}
+        {{country.name}}
+      {{/if}}
+    {{/power-select-with-create}}
+  `);
+
+  clickTrigger();
+  Ember.run(() => typeInSearch('Russ'));
+
+  assert.equal(
+    this.$('.is-suggested').length,
+    0
+  );
+});
+
+test('is yields the create option if set', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`
+    {{#power-select-with-create
+        options=countries
+        oncreate=(action "createCountry")
+        searchField='name'
+        showCreatePosition="bottom"
+        yieldCreateOption=true
+        renderInPlace=true as |country|
+    }}
+      {{#if country.isSuggestion}}
+        <span class="is-suggested">{{country.text}}</span>
+      {{else}}
+        {{country.name}}
+      {{/if}}
+    {{/power-select-with-create}}
+  `);
+
+  clickTrigger();
+  Ember.run(() => typeInSearch('Russ'));
+
+  assert.equal(
+    this.$('.is-suggested').length,
+    1
+  );
+});
+
 test('it executes the oncreate callback', function(assert) {
   assert.expect(1);
 

--- a/tests/integration/components/power-select-with-create-test.js
+++ b/tests/integration/components/power-select-with-create-test.js
@@ -137,7 +137,7 @@ test('it does not yield the create option by default', function(assert) {
         showCreatePosition="bottom"
         renderInPlace=true as |country|
     }}
-      {{#if country.isSuggestion}}
+      {{#if country.__isSuggestion__}}
         <span class="is-suggested">{{country.text}}</span>
       {{else}}
         {{country.name}}
@@ -166,7 +166,7 @@ test('is yields the create option if set', function(assert) {
         yieldCreateOption=true
         renderInPlace=true as |country|
     }}
-      {{#if country.isSuggestion}}
+      {{#if country.__isSuggestion__}}
         <span class="is-suggested">{{country.text}}</span>
       {{else}}
         {{country.name}}
@@ -228,6 +228,7 @@ test('it lets the user specify a custom search action', function(assert) {
 
   clickTrigger();
   Ember.run(() => typeInSearch('Foo Bar'));
+  debugger;
 
   const options = this.$('.ember-power-select-option');
   assert.equal(options.length, 3);


### PR DESCRIPTION
Added the ability to yield the create option.

Open to bike-shedding on property naming.

Of note, I moved the `__isSuggestion__` property out of private space to `isSuggestion`. I feel like the naming of this is specific enough that it will have minimal conflict with existing apps that could possibly have this property.

Finally, the README doesn't discuss `buildSuggestion`, though I mention it here. I wanted to add it but didn't want to pollute this PR. Will open separate PR to resolve.
