### PR TITLE
Add onInput action

### DIFF
--- a/addon/templates/components/power-select-with-create.hbs
+++ b/addon/templates/components/power-select-with-create.hbs
@@ -58,6 +58,7 @@
     selected=selected
     onchange=(action "selectOrCreate")
     onkeydown=onkeydown
+    oninput=oninput
     onfocus=onfocus
     onopen=onopen
     onclose=onclose


### PR DESCRIPTION
The up-to-date ember-power-select has an `oninput`, so it would be nice if ember-power-select-with-create would expose it as well.