### PR TITLE
[RFC] Search should work when options is a promise

### DIFF
--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -19,9 +19,7 @@ export default Ember.Component.extend({
     let options = this.get('options');
     if (!options) { return Ember.A(); }
     if (options.then) {
-      return options.then(value => {
-        return Ember.A(value).toArray();
-      });
+      return options.then(value => Ember.A(value).toArray());
     } else {
       return Ember.A(options).toArray();
     }

--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -19,7 +19,11 @@ export default Ember.Component.extend({
     let options = this.get('options');
     if (!options) { return Ember.A(); }
     if (options.then) {
-      return options.then(value => Ember.A(value).toArray());
+      return options.then(value => {
+        const resolvedOptionsArray = Ember.A(value).toArray();
+        this.set('resolvedOptionsArray', resolvedOptionsArray);
+        return resolvedOptionsArray;
+      });
     } else {
       return Ember.A(options).toArray();
     }
@@ -46,7 +50,7 @@ export default Ember.Component.extend({
   // Actions
   actions: {
     searchAndSuggest(term, select) {
-      let newOptions = this.get('optionsArray');
+      let newOptions = this.get('resolvedOptionsArray') || this.get('optionsArray');
 
       if (term.length === 0) {
         return newOptions;

--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/power-select-with-create';
 import { filterOptions, defaultMatcher } from 'ember-power-select/utils/group-utils';
-const { computed, get } = Ember;
+const { computed, get, RSVP } = Ember;
 
 export default Ember.Component.extend({
   tagName: '',
@@ -20,9 +20,7 @@ export default Ember.Component.extend({
     if (!options) { return Ember.A(); }
     if (options.then) {
       return options.then(value => {
-        const resolvedOptionsArray = Ember.A(value).toArray();
-        this.set('resolvedOptionsArray', resolvedOptionsArray);
-        return resolvedOptionsArray;
+        return Ember.A(value).toArray();
       });
     } else {
       return Ember.A(options).toArray();
@@ -50,27 +48,28 @@ export default Ember.Component.extend({
   // Actions
   actions: {
     searchAndSuggest(term, select) {
-      let newOptions = this.get('resolvedOptionsArray') || this.get('optionsArray');
+      return RSVP.resolve(this.get('optionsArray')).then(newOptions => {
 
-      if (term.length === 0) {
+        if (term.length === 0) {
+          return newOptions;
+        }
+
+        let searchAction = this.get('search');
+        if (searchAction) {
+          return Ember.RSVP.resolve(searchAction(term, select)).then((results) =>  {
+            if (results.toArray) {
+              results = results.toArray();
+            }
+            this.addCreateOption(term, results);
+            return results;
+          });
+        }
+
+        newOptions = this.filter(Ember.A(newOptions), term);
+        this.addCreateOption(term, newOptions);
+
         return newOptions;
-      }
-
-      let searchAction = this.get('search');
-      if (searchAction) {
-        return Ember.RSVP.resolve(searchAction(term, select)).then((results) =>  {
-          if (results.toArray) {
-            results = results.toArray();
-          }
-          this.addCreateOption(term, results);
-          return results;
-        });
-      }
-
-      newOptions = this.filter(Ember.A(newOptions), term);
-      this.addCreateOption(term, newOptions);
-
-      return newOptions;
+      });
     },
 
     selectOrCreate(selection, select) {


### PR DESCRIPTION
I've run into problems with searching options when options is a promise, which I did not have when using EPS itself. 

I believe this is addressed in EPS by making `options` a computed property and having it's computed `set` update if options is `thennable`.

This is an example of a fix to demonstrate the issue, but there are plenty of ways to patch this. I'm not sure which way you'd prefer, or if you'd prefer a more holistic fix.

Thanks!