### PR TITLE
Add possibility to use a custom component for creation

### DIFF
--- a/addon/templates/components/power-select-with-create.hbs
+++ b/addon/templates/components/power-select-with-create.hbs
@@ -43,7 +43,11 @@
     dir=dir
     as |option term|}}
     {{#if option.__isSuggestion__}}
-      {{option.text}}
+      {{#if createItemComponent}}
+        {{component createItemComponent option=option}}
+      {{else}}
+        {{option.text}}
+      {{/if}}
     {{else}}
       {{yield option term}}
     {{/if}}
@@ -94,7 +98,11 @@
     dir=dir
     as |option term|}}
     {{#if option.__isSuggestion__}}
-      {{option.text}}
+      {{#if createItemComponent}}
+        {{component createItemComponent option=option.text}}
+      {{else}}
+        {{option.text}}
+      {{/if}}
     {{else}}
       {{yield option term}}
     {{/if}}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
+    "ember-native-dom-helpers": "0.3.2",
     "ember-pagefront": "0.9.9",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.10"

--- a/tests/dummy/app/templates/components/create-item.hbs
+++ b/tests/dummy/app/templates/components/create-item.hbs
@@ -1,0 +1,1 @@
+<div class="create-item">{{option}}</div>

--- a/tests/integration/components/power-select-with-create-test.js
+++ b/tests/integration/components/power-select-with-create-test.js
@@ -2,6 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import { typeInSearch, clickTrigger, nativeMouseUp } from '../../helpers/ember-power-select';
+import { find } from 'ember-native-dom-helpers/test-support/helpers';
 
 moduleForComponent('power-select-with-create', 'Integration | Component | power select with create', {
   integration: true,
@@ -120,6 +121,121 @@ test('it displays option to add item with custom text at bottom', function(asser
   clickTrigger();
   Ember.run(() => typeInSearch('Russ'));
 
+  assert.equal(
+    this.$('.ember-power-select-option:eq(1)').text().trim(),
+    'Create Russ'
+  );
+});
+
+test('it displays option to add item with custom component', function(assert) {
+  assert.expect(2);
+
+  this.render(hbs`
+    {{#power-select-with-create
+        options=countries
+        oncreate=(action "createCountry")
+        createItemComponent='create-item'
+        renderInPlace=true as |country|
+    }}
+      {{country.name}}
+    {{/power-select-with-create}}
+  `);
+
+  clickTrigger();
+  Ember.run(() => typeInSearch('Foo Bar'));
+
+  assert.ok(find('.create-item', '.ember-power-select-option:eq(0)'), 'The custom component is rendered.');
+  assert.equal(
+    this.$('.ember-power-select-option:eq(0)').text().trim(),
+    'Add "Foo Bar"...'
+  );
+});
+
+test('it displays option to add item with custom text inside a custom component', function(assert) {
+  assert.expect(2);
+
+  this.on('customSuggestion', (term) => {
+    return `Create ${term}`;
+  });
+
+  this.render(hbs`
+    {{#power-select-with-create
+        options=countries
+        oncreate=(action "createCountry")
+        buildSuggestion=(action "customSuggestion")
+        createItemComponent='create-item'
+        renderInPlace=true as |country|
+    }}
+      {{country.name}}
+    {{/power-select-with-create}}
+  `);
+
+  clickTrigger();
+  Ember.run(() => typeInSearch('Foo Bar'));
+
+  assert.ok(find('.create-item', '.ember-power-select-option:eq(0)'), 'The custom component is rendered.');
+  assert.equal(
+    this.$('.ember-power-select-option:eq(0)').text().trim(),
+    'Create Foo Bar'
+  );
+});
+
+test('it displays option to add item with custom component at bottom', function(assert) {
+  assert.expect(2);
+
+  this.on('customSuggestion', (term) => {
+    return `Create ${term}`;
+  });
+
+  this.render(hbs`
+    {{#power-select-with-create
+        options=countries
+        oncreate=(action "createCountry")
+        buildSuggestion=(action "customSuggestion")
+        searchField='name'
+        showCreatePosition="bottom"
+        createItemComponent='create-item'
+        renderInPlace=true as |country|
+    }}
+      {{country.name}}
+    {{/power-select-with-create}}
+  `);
+
+  clickTrigger();
+  Ember.run(() => typeInSearch('Russ'));
+
+  assert.ok(find('.create-item', '.ember-power-select-option:eq(1)'), 'The custom component is rendered.');
+  assert.equal(
+    this.$('.ember-power-select-option:eq(1)').text().trim(),
+    'Create Russ'
+  );
+});
+
+test('it displays option to add item with custom text inside a custom component at bottom', function(assert) {
+  assert.expect(2);
+
+  this.on('customSuggestion', (term) => {
+    return `Create ${term}`;
+  });
+
+  this.render(hbs`
+    {{#power-select-with-create
+        options=countries
+        oncreate=(action "createCountry")
+        buildSuggestion=(action "customSuggestion")
+        searchField='name'
+        showCreatePosition="bottom"
+        createItemComponent='create-item'
+        renderInPlace=true as |country|
+    }}
+      {{country.name}}
+    {{/power-select-with-create}}
+  `);
+
+  clickTrigger();
+  Ember.run(() => typeInSearch('Russ'));
+
+  assert.ok(find('.create-item', '.ember-power-select-option:eq(1)'), 'The custom component is rendered.');
   assert.equal(
     this.$('.ember-power-select-option:eq(1)').text().trim(),
     'Create Russ'


### PR DESCRIPTION
This is my take at adding the possibility to customize the creation item!

It composes with the `buildSuggestion` action to set text based on the context where the component is used.

I also added tests and I know I added a dependency but you I wanted to do it the way you did in `ember-power-select` so… 😄 