### PR TITLE
Add missing defaultHighlighted property

### DIFF
--- a/addon/templates/components/power-select-with-create.hbs
+++ b/addon/templates/components/power-select-with-create.hbs
@@ -41,6 +41,7 @@
     destination=destination
     tabindex=tabindex
     dir=dir
+    defaultHighlighted=defaultHighlighted
     as |option term|}}
     {{#if option.__isSuggestion__}}
       {{component suggestedOptionComponent option=option term=term}}
@@ -92,6 +93,7 @@
     destination=destination
     tabindex=tabindex
     dir=dir
+    defaultHighlighted=defaultHighlighted
     as |option term|}}
     {{#if option.__isSuggestion__}}
       {{component suggestedOptionComponent option=option term=term}}


### PR DESCRIPTION
The property is described at `ember-power-select` API reference but is missing in `power-select-with-create` template bindings.