### PR TITLE
Passing allowClear=true breaks selectOrCreate()

### DIFF
--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -68,7 +68,7 @@ export default Ember.Component.extend({
   },
 
   selectOrCreate(selection, select) {
-    if (selection.__isSuggestion__) {
+    if (selection && selection.__isSuggestion__) {
       this.get('oncreate')(selection.__value__, select);
     } else {
       this.get('onchange')(selection, select);

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -5,6 +5,7 @@
     options=countries
     searchField="name"
     selected=selectedCountry
+    allowClear=true
     onchange=(action (mut selectedCountry))
     oncreate=(action "createCountry") as |country term|
 }}
@@ -33,6 +34,7 @@
     options=countries
     searchField="name"
     selected=selectedCountry
+    allowClear=true
     onchange=(action (mut selectedCountry))
     oncreate=(action "createCountry")
     buildSuggestion=capitalizeSuggestion as |country term|
@@ -47,6 +49,7 @@
     options=slowPromise
     searchField="name"
     selected=selectedCountry
+    allowClear=true
     onchange=(action (mut selectedCountry))
     oncreate=(action "createCountry") as |country term|
 }}
@@ -59,6 +62,7 @@
 {{#power-select-with-create
     search=(action "searchCountries")
     selected=selectedCountry
+    allowClear=true
     onchange=(action (mut selectedCountry))
     oncreate=(action "createCountry") as |country term|
 }}
@@ -72,6 +76,8 @@
     options=countries
     searchField="name"
     selected=selectedCountry
+    allowClear=true
+    onchange=(action (mut selectedCountry))
     oncreate=(action "createCountry")
     showCreateWhen=(action "hideCreateOptionOnSameName") as |country|
 }}


### PR DESCRIPTION
Using allowClear=true in the EPS-with-create component, clearing the selected value is breaking the selectOrCreate() action.

Refer:
https://ember-twiddle.com/cd70ac43c2f408c18dce05d6b1575f16?openFiles=templates.application.hbs%2C

Issues ID: [#60]