### PR TITLE
Pass `triggerId` to `power-select`

### DIFF
--- a/addon/templates/components/power-select-with-create.hbs
+++ b/addon/templates/components/power-select-with-create.hbs
@@ -36,6 +36,7 @@
   class=class
   triggerClass=triggerClass
   dropdownClass=dropdownClass
+  triggerId=triggerId
   extra=extra
   initiallyOpened=initiallyOpened
   matchTriggerWidth=matchTriggerWidth


### PR DESCRIPTION
Would allow setting the id attribute on the trigger, making `power-select-with-create` play nicer with labels.