### PR TITLE
Fix passing a custom triggerComponent to PowerSelectWithCreate

### DIFF
--- a/addon/components/power-select-with-create.hbs
+++ b/addon/components/power-select-with-create.hbs
@@ -50,7 +50,7 @@
     @selectedItemComponent={{@selectedItemComponent}}
     @tabindex={{@tabindex}}
     @triggerClass={{@triggerClass}}
-    @triggerComponent={{this.triggerComponent}}
+    @triggerComponent={{@triggerComponent}}
     @triggerId={{@triggerId}}
     @triggerRole={{@triggerRole}}
     @typeAheadMatcher={{@typeAheadMatcher}}

--- a/tests/integration/components/power-select-with-create-test.js
+++ b/tests/integration/components/power-select-with-create-test.js
@@ -1,4 +1,5 @@
 import { Promise } from 'rsvp';
+import Component from '@ember/component';
 import ArrayProxy from '@ember/array/proxy';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
@@ -420,5 +421,33 @@ module('Integration | Component | power select with create', function(hooks) {
     assert.dom(options[0]).hasText('Add "Foo"...');
     assert.dom(options[1]).hasText('Portugal');
     assert.dom(options[2]).hasText('Spain');
+  });
+
+  test('selected option can be customized using triggerComponent', async function(assert) {
+    assert.expect(3);
+
+    this.owner.register('component:selected-country', class extends Component {
+      layout = hbs`
+        <img src={{select.selected.flagUrl}} class="icon-flag {{if extra.coolFlagIcon "cool-flag-icon"}}" alt="Flag of {{select.selected.name}}">
+        {{select.selected.name}}
+      `
+    });
+
+    this.country = this.countries[1]; // Spain
+
+    await render(hbs`
+      <PowerSelectWithCreate
+        @selected={{country}}
+        @options={{this.countries}}
+        @triggerComponent="selected-country"
+        @onCreate={{this.createCountry}} as |country|
+      >
+        {{country.name}}
+      </PowerSelectWithCreate>
+    `);
+
+    assert.dom('.ember-power-select-status-icon').doesNotExist('The provided trigger component is not rendered');
+    assert.dom('.ember-power-select-trigger .icon-flag').exists('The custom flag appears.');
+    assert.dom('.ember-power-select-trigger').hasText('Spain', 'With the country name as the text.');
   });
 });


### PR DESCRIPTION
Fixes https://github.com/cibernox/ember-power-select-with-create/issues/117.

Passing a custom triggerComponent stopped working with the 0.9.0 release.

The test I've added is mostly copy/paste from the equivalent test in ember-power-select: https://github.com/cibernox/ember-power-select/blob/48569eaad0fb15a523b38a61e092ec71bfe6b8a0/tests/integration/components/power-select/customization-with-components-test.js#L14-L36