### PR TITLE
Restore suggestedOptionComponent argument.

### DIFF
--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -7,7 +7,7 @@ import { filterOptions, defaultMatcher } from 'ember-power-select/utils/group-ut
 
 export default class PowerSelectWithCreateComponent extends Component {
   matcher = defaultMatcher;
-  suggestedOptionComponent ='power-select-with-create/suggested-option';
+  suggestedOptionComponent = 'power-select-with-create/suggested-option';
   powerSelectComponentName = 'power-select';
 
   @tracked

--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -7,7 +7,7 @@ import { filterOptions, defaultMatcher } from 'ember-power-select/utils/group-ut
 
 export default class PowerSelectWithCreateComponent extends Component {
   matcher = defaultMatcher;
-  suggestedOptionComponent = 'power-select-with-create/suggested-option';
+  suggestedOptionComponent ='power-select-with-create/suggested-option';
   powerSelectComponentName = 'power-select';
 
   @tracked
@@ -17,6 +17,10 @@ export default class PowerSelectWithCreateComponent extends Component {
   constructor() {
     super(...arguments);
     assert('<PowerSelectWithCreate> requires an `onCreate` function', this.args.onCreate && typeof this.args.onCreate === 'function');
+
+    if (this.args.suggestedOptionComponent) {
+      this.suggestedOptionComponent = this.args.suggestedOptionComponent;
+    }
   }
 
   shouldShowCreateOption(term, options) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-power-select-with-create",
-  "version": "0.9.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-power-select-with-create",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/dummy/app/components/custom-suggested-option.hbs
+++ b/tests/dummy/app/components/custom-suggested-option.hbs
@@ -1,0 +1,3 @@
+<div class="custom-suggested-option">
+  Custom Component {{@term.lastSearchedText}}
+</div>

--- a/tests/integration/components/power-select-with-create-test.js
+++ b/tests/integration/components/power-select-with-create-test.js
@@ -451,8 +451,7 @@ module('Integration | Component | power select with create', function(hooks) {
     assert.dom('.ember-power-select-trigger').hasText('Spain', 'With the country name as the text.');
   });
 
-
-  test('it accepts a suggestedOptionComponent', async function(assert) {
+  test('it accepts a suggestedOptionComponent argument', async function(assert) {
     assert.expect(1);
 
     await render(hbs`

--- a/tests/integration/components/power-select-with-create-test.js
+++ b/tests/integration/components/power-select-with-create-test.js
@@ -450,4 +450,25 @@ module('Integration | Component | power select with create', function(hooks) {
     assert.dom('.ember-power-select-trigger .icon-flag').exists('The custom flag appears.');
     assert.dom('.ember-power-select-trigger').hasText('Spain', 'With the country name as the text.');
   });
+
+
+  test('it accepts a suggestedOptionComponent', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      <PowerSelectWithCreate
+        @options={{this.countries}}
+        @onCreate={{this.createCountry}}
+        @suggestedOptionComponent="custom-suggested-option"
+        @renderInPlace={{true}} as |country|
+      >
+        {{country.name}}
+      </PowerSelectWithCreate>
+    `);
+
+    await clickTrigger();
+    await typeInSearch('Foo Bar');
+
+    assert.dom('.ember-power-select-option').hasText('Custom Component Foo Bar');
+  });
 });


### PR DESCRIPTION
This PR fixes a regression (Issue #121) that I assume happened when upgrading to glimmer components.  This adds back the ability to pass in the `suggestedOptionComponent` argument.