### PR TITLE
Fix passing beforeOptionsComponent, matcher, suggestedOptionComponent and searchEnabled params

### DIFF
--- a/addon/components/power-select-with-create.hbs
+++ b/addon/components/power-select-with-create.hbs
@@ -6,7 +6,7 @@
     @ariaInvalid={{@ariaInvalid}}
     @ariaLabel={{@ariaLabel}}
     @ariaLabelledBy={{@ariaLabelledBy}}
-    @beforeOptionsComponent={{this.beforeOptionsComponent}}
+    @beforeOptionsComponent={{@beforeOptionsComponent}}
     @buildSelection={{@buildSelection}}
     @calculatePosition={{@calculatePosition}}
     @class={{@class}}
@@ -23,7 +23,7 @@
     @initiallyOpened={{@initiallyOpened}}
     @loadingMessage={{@loadingMessage}}
     @matchTriggerWidth={{@matchTriggerWidth}}
-    @matcher={{this.matcher}}
+    @matcher={{this.matcherWithFallback}}
     @noMatchesMessage={{@noMatchesMessage}}
     @onBlur={{@onBlur}}
     @onChange={{this.selectOrCreate}}
@@ -41,7 +41,7 @@
     @renderInPlace={{@renderInPlace}}
     @scrollTo={{@scrollTo}}
     @search={{this.searchAndSuggest}}
-    @searchEnabled={{this.searchEnabled}}
+    @searchEnabled={{this.searchEnabledWithFallback}}
     @searchField={{@searchField}}
     @searchMessage={{@searchMessage}}
     @searchMessageComponent={{@searchMessageComponent}}
@@ -59,7 +59,7 @@
     as |option term|
   >
     {{#if option.__isSuggestion__}}
-      {{component this.suggestedOptionComponent option=option term=term}}
+      {{component this.suggestedOptionComponentWithFallback option=option term=term}}
     {{else}}
       {{yield option term}}
     {{/if}}

--- a/addon/components/power-select-with-create.js
+++ b/addon/components/power-select-with-create.js
@@ -1,17 +1,32 @@
 import { assert } from '@ember/debug';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { get, action } from '@ember/object';
 import RSVP, { resolve } from 'rsvp';
 import { filterOptions, defaultMatcher } from 'ember-power-select/utils/group-utils';
 
 export default class PowerSelectWithCreateComponent extends Component {
-  matcher = defaultMatcher;
-  suggestedOptionComponent = 'power-select-with-create/suggested-option';
   powerSelectComponentName = 'power-select';
 
-  @tracked
-  searchEnabled = true;
+  get suggestedOptionComponentWithFallback() {
+    if (typeof this.args.suggestedOptionComponent !== 'undefined') {
+      return this.args.suggestedOptionComponent;
+    }
+    return 'power-select-with-create/suggested-option';
+  }
+
+  get searchEnabledWithFallback() {
+    if (typeof this.args.searchEnabled !== 'undefined') {
+      return this.args.searchEnabled;
+    }
+    return true;
+  }
+
+  get matcherWithFallback() {
+    if (typeof this.args.matcher !== 'undefined') {
+      return this.args.matcher;
+    }
+    return defaultMatcher;
+  }
 
   // Lifecycle hooks
   constructor() {


### PR DESCRIPTION
These params were written in a way that they couldn't be overwritten when creating an instance of PowerSelectWithCreate.