### PR TITLE
Add missing EventType property

### DIFF
--- a/addon/components/power-select-with-create.hbs
+++ b/addon/components/power-select-with-create.hbs
@@ -15,6 +15,7 @@
   @dir={{@dir}}
   @disabled={{@disabled}}
   @dropdownClass={{@dropdownClass}}
+  @eventType={{@eventType}}
   @extra={{@extra}}
   @groupComponent={{@groupComponent}}
   @highlightOnHover={{@highlightOnHover}}


### PR DESCRIPTION
:wave:

Opening this pull request just to add one property that might be useful for some users when they are using this library.
Power select library allows passing`eventType` prop down to specify types of the handler -> https://github.com/cibernox/ember-power-select/blob/master/addon/components/power-select.hbs#L29
And it looks like this library is missing that.

Please let me know if there is a better way of handling that PR! 
