### PR TITLE
Remove ember source peerDependency

### DIFF
--- a/ember-power-select-with-create/package.json
+++ b/ember-power-select-with-create/package.json
@@ -77,7 +77,6 @@
   },
   "peerDependencies": {
     "ember-basic-dropdown": "^8.1.0",
-    "ember-power-select": "^8.2.0",
-    "ember-source": "^3.28.0 || >= 4.0.0"
+    "ember-power-select": "^8.2.0"
   }
 }


### PR DESCRIPTION
ember-source: removed because the embroider / auto-import know what we intend - it's not bad to have if someone manages their dep graph correctly, which is easier with pnpm, but not everyone gets it right, and folks have a hard time tracking down errors

ref https://github.com/ember-cli/ember-addon-blueprint/pull/35